### PR TITLE
Remove duplicate comma in generated server code

### DIFF
--- a/src/service_gen.rs
+++ b/src/service_gen.rs
@@ -179,7 +179,7 @@ impl TwirpServiceGenerator {
                                 #mod_path::ProstTwirpError>> + Send + 'static>> {
                     let static_service = ::std::sync::Arc::clone(&self.0);
                     match req.uri().path() {
-                        #(#match_arms),*
+                        #(#match_arms)*
                         _ => Box::pin(::futures::future::ok(
                             #mod_path::ProstTwirpError::NotFound.into_hyper_response().unwrap()
                         ))


### PR DESCRIPTION
I tried adding more rpcs to my service, and they failed to generate the twirp bindings.
Did some digging into the following error, and the output had duplicate commas:

```
error: failed to run custom build command for `monsterland v0.1.0 (/home/shblakes/workspaces/rust-playground/monsterland)`

Caused by:
  process didn't exit successfully: `/home/shblakes/workspaces/rust-playground/monsterland/target/release/build/monsterland-c4100919a48fab72/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error("expected one of: `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`")', /home/shblakes/.cargo/registry/src/github.com-1ecc6299db9ec823/prost-build-0.11.8/src/lib.rs:1196:45
```

Since there is already a comma in the creation of `match_arms`, combining the vec elements with commas is what I believe to be the cause of the error.

Got this working locally by depending on my fork.

Example proto file that exposed the error:

```proto
syntax = "proto3";

package monsterland.kitchen;
option go_package = "cookbook";

message RecipesRequest {}

message RecipesResponse {}

message AddRecipeRequest {}

message AddRecipeResponse {}

// A CookBook manages recipes for cooks.
service CookBook {
  // Recipes
  rpc Recipes(RecipesRequest) returns (RecipesResponse){}
  // AddRecipe
  rpc AddRecipe(AddRecipeRequest) returns (AddRecipeResponse){}
}
```